### PR TITLE
feat: API local para controle externo de músicas

### DIFF
--- a/fmTransmitir.pas
+++ b/fmTransmitir.pas
@@ -145,6 +145,13 @@ begin
     Binding := IdHTTPServer1.Bindings.Add;
     Binding.Port := IdHTTPServer1.DefaultPort;
     Binding.IP := seSrvUrl.Text;
+    // Also bind to localhost for local API access (e.g., from web browsers)
+    if seSrvUrl.Text <> '127.0.0.1' then
+    begin
+      Binding := IdHTTPServer1.Bindings.Add;
+      Binding.Port := IdHTTPServer1.DefaultPort;
+      Binding.IP := '127.0.0.1';
+    end;
     try
       IdHTTPServer1.Active := True;
       btServidor.Enabled := True;
@@ -228,8 +235,51 @@ var
   url:string;
   arq:string;
   txt: TStringList;
+  songId: Integer;
 begin
+  // Allow cross-origin requests from web applications
+  AResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := '*';
+  AResponseInfo.CustomHeaders.Values['Access-Control-Allow-Methods'] := 'GET, OPTIONS';
+
   arq := ARequestInfo.Document;
+
+  // API: Health check endpoint (used by web apps to detect if LouvorJA is running)
+  if arq = '/api/ping' then
+  begin
+    AResponseInfo.ContentType := 'application/json';
+    AResponseInfo.CharSet := 'utf-8';
+    AResponseInfo.ContentText := '{"status":"ok","app":"LouvorJA"}';
+    Exit;
+  end;
+
+  // API: Open a song slide by its database ID
+  // Usage: GET /api/open-song?id=123
+  if arq = '/api/open-song' then
+  begin
+    AResponseInfo.ContentType := 'application/json';
+    AResponseInfo.CharSet := 'utf-8';
+    if TryStrToInt(ARequestInfo.Params.Values['id'], songId) then
+    begin
+      TThread.Queue(nil,
+        procedure
+        begin
+          if Assigned(fmIndex) then
+            fmIndex.abreLetraMusica('BD', '', songId, True);
+        end
+      );
+      AResponseInfo.ContentText :=
+        '{"status":"ok","action":"open-song","id":' + IntToStr(songId) + '}';
+    end
+    else
+    begin
+      AResponseInfo.ResponseNo := 400;
+      AResponseInfo.ContentText :=
+        '{"status":"error","message":"Missing or invalid song ID. Usage: /api/open-song?id=123"}';
+    end;
+    Exit;
+  end;
+
+  // Static file serving (existing behavior)
   if (Trim(arq) = '') or (Trim(arq) = '/') then
     arq := '/index.htm';
   if (Trim(arq) = '/musica') or (Trim(arq) = '/musica/') or
@@ -242,8 +292,12 @@ begin
     url := fmIndex.dir_config+'server'+arq;
   end;
   txt := TStringList.Create;
-  txt.LoadFromFile(url);
-  AResponseInfo.ContentText := txt.Text;
+  try
+    txt.LoadFromFile(url);
+    AResponseInfo.ContentText := txt.Text;
+  finally
+    txt.Free;
+  end;
 end;
 
 procedure TfTransmitir.seSrvUrlExit(Sender: TObject);


### PR DESCRIPTION
Primeiramente, parabéns pelo LouvorJA! É um app incrível que se tornou referência nas igrejas adventistas do Brasil.                                                                                                                           
                                         
  Na nossa igreja, em Belo Horizonte, usamos há anos e não trocamos por nada — a praticidade dos slides com áudio sincronizado, o acervo completo de hinos e coletâneas, tudo funciona muito bem.                                                
                                                            
  Com o tempo, nossa igreja desenvolveu um site próprio para organização interna — escalas de louvor, repertório, membros, etc ([IASD Ermelinda](https://iasdermelinda.com.br)). Surgiu uma necessidade natural: quando alguém está no site      
  consultando o repertório, seria muito prático clicar em um botão e abrir o slide diretamente no LouvorJA, sem precisar minimizar o navegador, abrir o app, buscar a mesma música manualmente e só então projetar.

  **Essa PR adiciona dois endpoints simples ao servidor HTTP que já existe no LouvorJA**, permitindo que qualquer aplicação web local detecte o app rodando e abra slides nativos com um clique — sem apps intermediários e sem alterar nenhum
  comportamento existente.

  Acredito que essa mudança pode beneficiar toda a comunidade: qualquer igreja que tenha um site, sistema interno ou ferramenta própria poderá se integrar ao LouvorJA de forma simples. Isso amplia o valor do app sem aumentar sua
  complexidade, transformando-o em uma plataforma ainda mais versátil para o ecossistema de tecnologia das igrejas.

  ## O que foi alterado

  Dois endpoints JSON adicionados ao servidor HTTP existente (`fmTransmitir.pas`):

  | Endpoint | Descrição |
  |----------|-----------|
  | `GET /api/ping` | Detecta se o LouvorJA está rodando |
  | `GET /api/open-song?id=123` | Abre o slide nativo da música pelo ID do banco |

  ### Exemplo de integração (JavaScript)

  ```js
  // Detectar se LouvorJA está rodando
  const isRunning = await fetch('http://127.0.0.1:7070/api/ping')
    .then(r => r.json())
    .catch(() => null);

  // Abrir uma música
  if (isRunning) {
    await fetch('http://127.0.0.1:7070/api/open-song?id=42');
  }
```

  Detalhes técnicos

  - CORS habilitado (Access-Control-Allow-Origin: *) para acesso cross-origin
  - Thread-safe: TThread.Queue garante que abreLetraMusica execute na thread VCL principal
  - Binding 127.0.0.1 adicionado automaticamente para acesso local confiável
  - Memory leak corrigido: TStringList no handler de arquivos estáticos agora tem try/finally
  - Zero impacto nos endpoints existentes — comportamento atual 100% preservado

  Escopo da alteração

  - 1 arquivo modificado: fmTransmitir.pas
  - 56 linhas adicionadas, 2 removidas (fix do memory leak)
  - Nenhuma dependência nova
  - Nenhum componente visual alterado
  - Nenhum arquivo .dfm modificado