### PR TITLE
Bypass de validação de token para requests localhost

### DIFF
--- a/fmTransmitir.pas
+++ b/fmTransmitir.pas
@@ -285,6 +285,7 @@ var
   tagValue: Integer;
   txtModo: string;
   tocarAudio: Boolean;
+  isLocalRequest: Boolean;
 begin
   // Allow cross-origin requests from web applications
   AResponseInfo.CustomHeaders.Values['Access-Control-Allow-Origin'] := '*';
@@ -292,13 +293,20 @@ begin
 
   arq := ARequestInfo.Document;
 
+  // Requests via localhost (127.0.0.1) are trusted — only processes on the
+  // same machine can reach this binding. Token is only required for network access.
+  // AContext.Binding.IP returns the server-side socket address (getsockname),
+  // which cannot be spoofed by a remote client.
+  isLocalRequest := (AContext.Binding.IP = '127.0.0.1');
+
   // API: Health check endpoint (used by web apps to detect if LouvorJA is running)
   if arq = '/api/ping' then
   begin
     AResponseInfo.ContentType := 'application/json';
     AResponseInfo.CharSet := 'utf-8';
 
-    if (ARequestInfo.Params.Values['token'] <> fmIndex.lerParam('Servidor', 'Token','')) then
+    if (not isLocalRequest) and
+       (ARequestInfo.Params.Values['token'] <> fmIndex.lerParam('Servidor', 'Token','')) then
     begin
       AResponseInfo.ContentText := '{"status":"error","message":"Invalid token","code":"INVALID_TOKEN"}';
       Exit;
@@ -315,7 +323,8 @@ begin
     AResponseInfo.ContentType := 'application/json';
     AResponseInfo.CharSet := 'utf-8';
 
-    if (ARequestInfo.Params.Values['token'] <> fmIndex.lerParam('Servidor', 'Token','')) then
+    if (not isLocalRequest) and
+       (ARequestInfo.Params.Values['token'] <> fmIndex.lerParam('Servidor', 'Token','')) then
     begin
       AResponseInfo.ContentText := '{"status":"error","message":"Invalid token","code":"INVALID_TOKEN"}';
       Exit;


### PR DESCRIPTION
### Problema                                                                                                                                                 
                                                                                                                                                           
A autenticação por token nos endpoints da API protege contra acesso não autorizado pela rede, mas também bloqueia integrações legítimas que rodam na mesma máquina — como apps web que acessam a API via 127.0.0.1:7070. Nesses casos, exigir que o usuário configure um token manualmente é atrito sem ganho  de segurança.                                       

### Solução
Exigir token apenas para requests que chegam pelo binding de rede. Requests via localhost (127.0.0.1) são liberados automaticamente.

A verificação usa AContext.Binding.IP, que vem de getsockname() no kernel — não depende de headers HTTP e não pode ser forjado pelo cliente.

```
if (AContext.Binding.IP <> '127.0.0.1') and
   (ARequestInfo.Params.Values['token'] <> fmIndex.lerParam('Servidor', 'Token','')) then
begin
  AResponseInfo.ContentText := '{"status":"error","message":"Invalid token","code":"INVALID_TOKEN"}';
  Exit;
end;
```

### Resultado
- Rede → token continua obrigatório (sem mudança)
- Localhost → acesso liberado, sem configuração — apenas processos na própria máquina alcançam 127.0.0.1