### PR TITLE
Fix: blindagem UTF-8 e race condition no modal de liturgia

### DIFF
--- a/fmLiturgia.pas
+++ b/fmLiturgia.pas
@@ -1,4 +1,4 @@
-unit fmLiturgia;
+ï»¿unit fmLiturgia;
 
 interface
 
@@ -141,6 +141,15 @@ var
   tipo: string;
   subitem: string;
   param: string;
+  itens: array of TParamItem;
+
+  procedure Add(const p, v: string);
+  begin
+    SetLength(itens, Length(itens)+1);
+    itens[High(itens)].Grupo := id;
+    itens[High(itens)].Param := p;
+    itens[High(itens)].Valor := v;
+  end;
 begin
   if (cbItens.ItemIndex < 0) then
   begin
@@ -178,28 +187,33 @@ begin
     5: tipo := 'site';
   end;
 
-  fmIndex.gravaParam(id, 'tipo', tipo, fmIndex.arq_liturgia);
-  fmIndex.gravaParam(id, 'item', txtItem.Text, fmIndex.arq_liturgia);
-  fmIndex.gravaParam(id, 'cor', ColorToString(csCor.ColorValue), fmIndex.arq_liturgia);
+  Add('tipo', tipo);
+  Add('item', txtItem.Text);
+  Add('cor', ColorToString(csCor.ColorValue));
 
+  try
+    fmIndex.gravaLog('btAddClick: pre-build id=' + id + ' pnlArquivo=' + BoolToStr(pnlArquivo.Visible, True) + ' edtDiretorio=' + edtDiretorio.Text + ' edtDiretorioInfo=' + edtDiretorioInfo.Text);
+  except
+    // silencioso
+  end;
 
   if (pnlAnotacoes.Visible) then
   begin
-    fmIndex.gravaParam(id, 'subitem', edtAnotacao.Text, fmIndex.arq_liturgia);
+    Add('subitem', edtAnotacao.Text);
   end
   else
   if (pnlItensAgendados.Visible) then
   begin
-    fmIndex.gravaParam(id, 'item', dblItem.Text, fmIndex.arq_liturgia);
-    fmIndex.gravaParam(id, 'subitem', '', fmIndex.arq_liturgia);
-    fmIndex.gravaParam(id, 'id', dblItem.KeyValue, fmIndex.arq_liturgia);
+    Add('item', dblItem.Text);
+    Add('subitem', '');
+    Add('id', dblItem.KeyValue);
   end
   else
   if (pnlSite.Visible) then
   begin
     urlSite.text := validaURL(urlSite.text);
-    fmIndex.gravaParam(id, 'subitem', 'Site '+urlSite.Text, fmIndex.arq_liturgia);
-    fmIndex.gravaParam(id, 'url', urlSite.Text, fmIndex.arq_liturgia);
+    Add('subitem', 'Site '+urlSite.Text);
+    Add('url', urlSite.Text);
   end
   else
   if (pnlArquivo.Visible) then
@@ -211,28 +225,28 @@ begin
 
     if (Copy(param,Length(param),1) = '\') then
     begin
-      fmIndex.gravaParam(id, 'subtipo', 'dir', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'subitem', 'Pasta '+edtDiretorio.Text, fmIndex.arq_liturgia);
+      Add('subtipo', 'dir');
+      Add('subitem', 'Pasta '+edtDiretorio.Text);
     end
     else if FileExists(param) then
     begin
-      fmIndex.gravaParam(id, 'subtipo', 'arq', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'subitem', 'Arquivo '+edtDiretorio.Text, fmIndex.arq_liturgia);
+      Add('subtipo', 'arq');
+      Add('subitem', 'Arquivo '+edtDiretorio.Text);
     end
     else if DirectoryExists(param) then
     begin
       edtDiretorio.Text := edtDiretorio.Text+'\';
-      fmIndex.gravaParam(id, 'subtipo', 'dir', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'subitem', 'Pasta '+edtDiretorio.Text, fmIndex.arq_liturgia);
+      Add('subtipo', 'dir');
+      Add('subitem', 'Pasta '+edtDiretorio.Text);
     end
     else
     begin
-      fmIndex.gravaParam(id, 'subtipo', 'arq', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'subitem', 'Arquivo '+edtDiretorio.Text, fmIndex.arq_liturgia);
+      Add('subtipo', 'arq');
+      Add('subitem', 'Arquivo '+edtDiretorio.Text);
     end;
 
-    fmIndex.gravaParam(id, 'dir', edtDiretorio.Text, fmIndex.arq_liturgia);
-    fmIndex.gravaParam(id, 'dir_info', edtDiretorioInfo.Text, fmIndex.arq_liturgia);
+    Add('dir', edtDiretorio.Text);
+    Add('dir_info', edtDiretorioInfo.Text);
   end
   else
   if (pnlHinos.Visible) then
@@ -242,30 +256,37 @@ begin
 
     if opcHinosOpc1.Checked then
     begin
-      fmIndex.gravaParam(id, 'escolha', '1', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'musica', '-1', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'subtipo', 'escolha', fmIndex.arq_liturgia);
-      subitem := 'Clique para escolher a música';
-      fmIndex.gravaParam(id, 'subitem', subitem, fmIndex.arq_liturgia);
+      Add('escolha', '1');
+      Add('musica', '-1');
+      Add('subtipo', 'escolha');
+      subitem := 'Clique para escolher a mÃºsica';
+      Add('subitem', subitem);
     end
     else
     begin
-      fmIndex.gravaParam(id, 'escolha', '0', fmIndex.arq_liturgia);
-      fmIndex.gravaParam(id, 'musica', IntToStr(dbLitHinoLista.KeyValue), fmIndex.arq_liturgia);
+      Add('escolha', '0');
+      Add('musica', IntToStr(dbLitHinoLista.KeyValue));
       if (qrHinos.FieldByName('TIPO_HASD').AsString = 'S')
-        then fmIndex.gravaParam(id, 'subtipo', 'hasd', fmIndex.arq_liturgia)
+        then Add('subtipo', 'hasd')
       else if (qrHinos.FieldByName('TIPO_JA').AsString = 'S')
-        then fmIndex.gravaParam(id, 'subtipo', 'ja', fmIndex.arq_liturgia)
-      else fmIndex.gravaParam(id, 'subtipo', 'div', fmIndex.arq_liturgia);
+        then Add('subtipo', 'ja')
+      else Add('subtipo', 'div');
 
       if (qrHinos.FieldByName('TIPO_HASD').AsString = 'S')
-        then subitem := 'Hino nº '
-        else subitem := 'Música ';
+        then subitem := 'Hino nÂº '
+        else subitem := 'MÃºsica ';
       subitem := subitem + qrHinos.FieldByName('NOME').AsString;
-      fmIndex.gravaParam(id, 'subitem', subitem, fmIndex.arq_liturgia);
+      Add('subitem', subitem);
     end;
   end;
 
+  fmIndex.gravaParamLote(fmIndex.arq_liturgia, itens);
+
+  try
+    fmIndex.gravaLog('btAddClick: salvando item ' + id + ' tipo=' + tipo);
+  except
+    // silencioso: log falhou -> continua
+  end;
 
   if fmIndex.lbLiturgia.Items.IndexOf(id) < 0 then
   begin
@@ -286,20 +307,27 @@ begin
 end;
 
 procedure TfLiturgia.cbItensChange(Sender: TObject);
+const
+  IDX_ANOTACAO       = 0;
+  IDX_ARQUIVO        = 1;
+  IDX_ITENSAGENDADOS = 3;
+  IDX_MUSICA         = 4;
+  IDX_SITE           = 5;
+var
+  idx: Integer;
 begin
-  lblItem.Visible := True;
-  txtItem.Visible := True;
-  if cbItens.ItemIndex < 0 then Exit;
+  idx := cbItens.ItemIndex;
 
-  pnlAnotacoes.Visible := (cbItens.Items[cbItens.ItemIndex] = 'Anotação');
-  pnlHinos.Visible := (cbItens.Items[cbItens.ItemIndex] = 'Música');
-  pnlSite.Visible := (cbItens.Items[cbItens.ItemIndex] = 'Site');
-  pnlArquivo.Visible := (cbItens.Items[cbItens.ItemIndex] = 'Arquivo/Diretório');
-  pnlItensAgendados.Visible := (cbItens.Items[cbItens.ItemIndex] = 'Itens Agendados');
+  pnlAnotacoes.Visible      := (idx = IDX_ANOTACAO);
+  pnlArquivo.Visible        := (idx = IDX_ARQUIVO);
+  pnlItensAgendados.Visible := (idx = IDX_ITENSAGENDADOS);
+  pnlHinos.Visible          := (idx = IDX_MUSICA);
+  pnlSite.Visible           := (idx = IDX_SITE);
 
   lblItem.Visible := not pnlItensAgendados.Visible;
   txtItem.Visible := not pnlItensAgendados.Visible;
 
+  if idx < 0 then Exit;
   executaOpcoes;
 end;
 
@@ -307,35 +335,81 @@ procedure TfLiturgia.executaOpcoes;
 var
   item: string;
 begin
-  if (pnlHinos.Visible) then
-  begin
-    opcHinosOpc1Click(nil);
-    qrHinos.Close;
-    qrHinos.Open;
-  end
-  else if pnlItensAgendados.Visible then
-  begin
-    item := '';
-    if (dblItem.KeyValue <> null) then
-      item := dblItem.KeyValue;
-    if not DM.cdsCategoriasItensAgendados.Active then
+  try
+    if (pnlHinos.Visible) then
     begin
-      DM.cdsCategoriasItensAgendados.CreateDataSet;
-      DM.cdsCategoriasItensAgendados.IndexName := '';
-      DM.cdsCategoriasItensAgendados.IndexFieldNames := 'NOME';
-      DM.cdsCategoriasItensAgendados.LogChanges := False;
-    end;
+      opcHinosOpc1Click(nil);
+      qrHinos.Close;
+      qrHinos.Open;
+    end
+    else if pnlItensAgendados.Visible then
+    begin
+      item := '';
+      if (dblItem.KeyValue <> null) then
+        item := dblItem.KeyValue;
+      if not DM.cdsCategoriasItensAgendados.Active then
+      begin
+        DM.cdsCategoriasItensAgendados.CreateDataSet;
+        DM.cdsCategoriasItensAgendados.IndexName := '';
+        DM.cdsCategoriasItensAgendados.IndexFieldNames := 'NOME';
+        DM.cdsCategoriasItensAgendados.LogChanges := False;
+      end;
 
-    if (FileExists(fmIndex.dir_dados + 'itensAgendadosCategorias.xml')) then
-      DM.cdsCategoriasItensAgendados.LoadFromFile(fmIndex.dir_dados + 'itensAgendadosCategorias.xml');
-    DM.cdsCategoriasItensAgendados.Open;
-    dblItem.KeyValue := item;
+      if (FileExists(fmIndex.dir_dados + 'itensAgendadosCategorias.xml')) then
+        DM.cdsCategoriasItensAgendados.LoadFromFile(fmIndex.dir_dados + 'itensAgendadosCategorias.xml');
+      DM.cdsCategoriasItensAgendados.Open;
+      dblItem.KeyValue := item;
+    end;
+  except
+    // Silencioso - erros em opÃ§Ãµes nÃ£o devem quebrar a UI
   end;
 end;
 
 procedure TfLiturgia.FormActivate(Sender: TObject);
 var
   tipo: string;
+  idx: Integer;
+  function FindIndexForTipo(const code: string): Integer;
+  var
+    i: Integer;
+    c: string;
+  begin
+    Result := -1;
+    if Trim(code) = '' then Exit;
+    // try direct code-index mapping (legacy behavior)
+    Result := AnsiIndexStr(code, ['anotacao','arquivo','categoria','itensagendados','musica','site']);
+    if (Result >= 0) and (Result < cbItens.Items.Count) then Exit;
+
+    // fallback: match by partial label (case-insensitive)
+    for i := 0 to cbItens.Items.Count - 1 do
+    begin
+      c := cbItens.Items[i];
+      if AnsiContainsText(c, 'Anot') and ((code = 'anotacao')) then
+      begin
+        Result := i; Exit;
+      end;
+      if (AnsiContainsText(c, 'Arquiv') or AnsiContainsText(c, 'Diretor') or AnsiContainsText(c, 'Diret')) and (code = 'arquivo') then
+      begin
+        Result := i; Exit;
+      end;
+      if AnsiContainsText(c, 'Categor') and (code = 'categoria') then
+      begin
+        Result := i; Exit;
+      end;
+      if (AnsiContainsText(c, 'Itens') or AnsiContainsText(c, 'Agend')) and (code = 'itensagendados') then
+      begin
+        Result := i; Exit;
+      end;
+      if (AnsiContainsText(c, 'MÃºsic') or AnsiContainsText(c, 'Musica') or AnsiContainsText(c, 'Hino')) and (code = 'musica') then
+      begin
+        Result := i; Exit;
+      end;
+      if AnsiContainsText(c, 'Site') and (code = 'site') then
+      begin
+        Result := i; Exit;
+      end;
+    end;
+  end;
 begin
   pnlAnotacoes.Visible := False;
   pnlHinos.Visible := False;
@@ -357,34 +431,66 @@ begin
     btDel.Visible := True;
   end;
 
-  tipo := fmIndex.lerParam(id, 'tipo', '', fmIndex.arq_liturgia);
-  if tipo = 'anotacao'
-    then edtAnotacao.Text := fmIndex.lerParam(id, 'subitem', '', fmIndex.arq_liturgia)
-    else edtAnotacao.Text := '';
-  if tipo = 'site'
-    then urlSite.Text := fmIndex.lerParam(id, 'url', '', fmIndex.arq_liturgia)
-    else urlSite.Text := '';
-  if tipo = 'arquivo' then
-  begin
-    edtDiretorio.Text := fmIndex.lerParam(id, 'dir', '', fmIndex.arq_liturgia);
-    edtDiretorioInfo.Text := fmIndex.lerParam(id, 'dir_info', '', fmIndex.arq_liturgia);
-  end
-  else
-  begin
-    edtDiretorio.Text := '';
-    edtDiretorioInfo.Text := '';
-  end;
-  if tipo = 'itensagendados'
-    then dblItem.KeyValue := fmIndex.lerParam(id, 'id', '', fmIndex.arq_liturgia)
-    else dblItem.KeyValue := '';
-  opcHinosOpc1.Checked := (fmIndex.lerParam(id, 'escolha', '0', fmIndex.arq_liturgia) = '1');
-  txtItem.Text := fmIndex.lerParam(id, 'item', '', fmIndex.arq_liturgia);
-  csCor.ColorValue := StringToColor(fmIndex.lerParam(id, 'cor', '$004F0000', fmIndex.arq_liturgia));
-  dbLitHinoLista.KeyValue := fmIndex.lerParam(id, 'musica', '-1', fmIndex.arq_liturgia);
-  cbItens.ItemIndex := AnsiIndexStr(fmIndex.lerParam(id, 'tipo', '$004F0000', fmIndex.arq_liturgia),
-                               ['anotacao', 'arquivo','categoria','itensagendados','musica','site']);
+  try
+    fmIndex.gravaLog('FormActivate: carrega item ' + id);
+    tipo := fmIndex.lerParam(id, 'tipo', '', fmIndex.arq_liturgia);
 
-  cbItensChange(Sender);
+    // Prefill simple controls that do not require datasets
+    if tipo = 'anotacao' then
+      edtAnotacao.Text := fmIndex.lerParam(id, 'subitem', '', fmIndex.arq_liturgia)
+    else
+      edtAnotacao.Text := '';
+
+    if tipo = 'site' then
+      urlSite.Text := fmIndex.lerParam(id, 'url', '', fmIndex.arq_liturgia)
+    else
+      urlSite.Text := '';
+
+    if tipo = 'arquivo' then
+    begin
+      edtDiretorio.Text := fmIndex.lerParam(id, 'dir', '', fmIndex.arq_liturgia);
+      edtDiretorioInfo.Text := fmIndex.lerParam(id, 'dir_info', '', fmIndex.arq_liturgia);
+    end
+    else
+    begin
+      edtDiretorio.Text := '';
+      edtDiretorioInfo.Text := '';
+    end;
+
+      opcHinosOpc1.Checked := (fmIndex.lerParam(id, 'escolha', '0', fmIndex.arq_liturgia) = '1');
+      txtItem.Text := fmIndex.lerParam(id, 'item', '', fmIndex.arq_liturgia);
+      csCor.ColorValue := StringToColor(fmIndex.lerParam(id, 'cor', '$004F0000', fmIndex.arq_liturgia));
+
+      // Map and set ItemIndex so cbItensChange opens datasets before KeyValue assignment
+      try
+        idx := FindIndexForTipo(tipo);
+        if idx >= 0 then
+          cbItens.ItemIndex := idx
+        else
+        begin
+          cbItens.ItemIndex := -1;
+          fmIndex.gravaLog('FormActivate: tipo desconhecido para item ' + id + ' -> "' + tipo + '"');
+        end;
+      except
+        cbItens.ItemIndex := -1;
+        fmIndex.gravaLog('FormActivate: erro ao mapear tipo para item ' + id);
+      end;
+
+    // Ensure datasets and lookup lists are initialized
+    cbItensChange(Sender);
+
+    // Now safe to assign DB lookup KeyValues
+    if tipo = 'itensagendados' then
+      dblItem.KeyValue := fmIndex.lerParam(id, 'id', '', fmIndex.arq_liturgia)
+    else
+      dblItem.KeyValue := '';
+
+    dbLitHinoLista.KeyValue := fmIndex.lerParam(id, 'musica', '-1', fmIndex.arq_liturgia);
+
+  except
+    cbItens.ItemIndex := -1;
+    try fmIndex.gravaLog('FormActivate: excecao ao carregar item ' + id); except end;
+  end;
 end;
 
 procedure TfLiturgia.FormKeyUp(Sender: TObject; var Key: Word;

--- a/fmMenu.dfm
+++ b/fmMenu.dfm
@@ -15475,7 +15475,7 @@ object fmIndex: TfmIndex
           ScrollBars = ssVertical
           Align = alClient
           Color = clWhite
-          Font.Charset = ANSI_CHARSET
+          Font.Charset = DEFAULT_CHARSET
           Font.Color = clBlack
           Font.Height = -12
           Font.Name = 'Tahoma'

--- a/fmMenu.pas
+++ b/fmMenu.pas
@@ -1,4 +1,4 @@
-unit fmMenu;
+﻿unit fmMenu;
 
 interface
 
@@ -26,6 +26,11 @@ type
     Top: Integer;
     Width: Integer;
     Height: Integer;
+  end;
+  TParamItem = record
+    Grupo: string;
+    Param: string;
+    Valor: string;
   end;
   TfmIndex = class(TForm)
     IdAntiFreeze1: TIdAntiFreeze;
@@ -1747,6 +1752,7 @@ type
     procedure txtDecrExit(Sender: TObject);
     function lerParam(Grupo, Param, Valor: string;Arquivo: string = ''; Diretorio:string = ''): string;
     procedure gravaParam(Grupo, Param, Valor: string;Arquivo: string = '');
+    procedure gravaParamLote(const Arquivo: string; const Itens: array of TParamItem);
     procedure gravaParamServer(Grupo, Param, Valor: string);
     procedure apagaParam(Grupo: string; Param: string = '';Arquivo: string = '');
     procedure cbMusicaChange(Sender: TObject);
@@ -2245,6 +2251,7 @@ type
     move_x,move_y:integer;
     move_panel: TPanel;
     move: Boolean;
+    FLogChamadas: Integer;  // contador para checagem de truncamento do louvorja.log
 
     const
       VERSAO_MIN_BD: integer = 140;
@@ -2260,6 +2267,11 @@ type
     procedure ApplicationDeactivate(Sender: TObject);
     procedure ApplicationActivate(Sender: TObject);
     procedure ForceDirectoriesRecursive(const Path: string);
+
+    //Helpers internos para acesso ao liturgia.ja (UTF-8 garantido + migração on-demand)
+    function caminhoLiturgia: string;
+    procedure garanteUtf8Liturgia;
+    function abreIniLiturgia: TMemIniFile;
 
   public
     { Public declarations }
@@ -2687,10 +2699,19 @@ end;
 procedure TfmIndex.salvaItensLiturgia;
 var
   semana: string;
+  itens: array[0..1] of TParamItem;
 begin
   semana := fmIndex.loadCol.Strings.Values['LITURGIA:SEMANA'];
-  gravaParam('Geral', semana, StringReplace(lbLiturgia.Items.Text, #13#10, ';', [rfIgnoreCase, rfReplaceAll]), arq_liturgia);
-  gravaParam('Geral', 'AlteraOrdem-'+semana, FormatDateTime('dd/mm/yyyy hh:mm:ss',now()), arq_liturgia);
+
+  itens[0].Grupo := 'Geral';
+  itens[0].Param := semana;
+  itens[0].Valor := StringReplace(lbLiturgia.Items.Text, #13#10, ';', [rfIgnoreCase, rfReplaceAll]);
+
+  itens[1].Grupo := 'Geral';
+  itens[1].Param := 'AlteraOrdem-' + semana;
+  itens[1].Valor := FormatDateTime('dd/mm/yyyy hh:mm:ss', now());
+
+  gravaParamLote(arq_liturgia, itens);
 end;
 
 procedure TfmIndex.SaveBase64ImageToFile(const Base64String, FilePath: string);
@@ -5808,36 +5829,11 @@ begin
 end;
 
 procedure TfmIndex.carregaLiturgia(semana: Integer);
-  procedure MigrarParaUtf8;
-  var
-    path: string;
-    fs: TFileStream;
-    bom: array[0..2] of Byte;
-    sl: TStringList;
-  begin
-    path := dir_dados + arq_liturgia;
-    if not FileExists(path) then Exit;
-    FillChar(bom, SizeOf(bom), 0);
-    fs := TFileStream.Create(path, fmOpenRead or fmShareDenyWrite);
-    try
-      if fs.Size >= 3 then fs.Read(bom, 3);
-    finally
-      fs.Free;
-    end;
-    if (bom[0] = $EF) and (bom[1] = $BB) and (bom[2] = $BF) then Exit;
-    sl := TStringList.Create;
-    try
-      sl.LoadFromFile(path);
-      sl.SaveToFile(path, TEncoding.UTF8);
-    finally
-      sl.Free;
-    end;
-  end;
 var
   itens: TStringList;
   i: integer;
 begin
-  MigrarParaUtf8;
+  garanteUtf8Liturgia;
   itens := TStringList.Create;
   itens.Delimiter := ';';
   itens.DelimitedText := lerParam('Geral', IntToStr(semana), '', arq_liturgia);
@@ -6152,8 +6148,9 @@ begin
     else dir := dir_dados;
 
   try
+    // Always use abreIniLiturgia for liturgia.ja to ensure UTF-8 and avoid ANSI APIs
     if Arquivo = arq_liturgia then
-      ArqIni := TMemIniFile.Create(dir + Arquivo, TEncoding.UTF8)
+      ArqIni := abreIniLiturgia
     else
       ArqIni := TIniFile.Create(dir + Arquivo);
     try
@@ -6162,7 +6159,14 @@ begin
       ArqIni.Free;
     end;
   except
-    //
+    on E: Exception do
+    begin
+      try
+        gravaLog('lerParam(' + Arquivo + ',' + Grupo + ',' + Param + '): ' + E.ClassName + ' - ' + E.Message);
+      except
+        // Silencioso - erro ao logar não deve quebrar a app
+      end;
+    end;
   end;
   result := vl;
 end;
@@ -6181,32 +6185,352 @@ begin
   result := link;
 end;
 
-procedure TfmIndex.gravaLog(txt:string);
+function TfmIndex.caminhoLiturgia: string;
 begin
-  mmLog.Lines.Add(FormatDateTime('dd/mm/yyyy HH:MM:SS.ZZZ', now()) + '    ' + txt);
+  Result := dir_dados + arq_liturgia;
+end;
+
+procedure TfmIndex.garanteUtf8Liturgia;
+var
+  path: string;
+  fs: TFileStream;
+  bom: array[0..2] of Byte;
+  sl: TStringList;
+  enc1252: TEncoding;
+begin
+  path := caminhoLiturgia;
+  if not FileExists(path) then Exit;
+  FillChar(bom, SizeOf(bom), 0);
+  try
+    fs := TFileStream.Create(path, fmOpenRead or fmShareDenyWrite);
+    try
+      if fs.Size >= 3 then fs.Read(bom, 3);
+    finally
+      fs.Free;
+    end;
+  except
+    Exit;
+  end;
+  // If file already has UTF-8 BOM, assume UTF-8 and exit
+  if (bom[0] = $EF) and (bom[1] = $BB) and (bom[2] = $BF) then Exit;
+
+  sl := TStringList.Create;
+  try
+    // First try reading as UTF-8 (no BOM). If it succeeds, assume file is valid UTF-8.
+    try
+      sl.LoadFromFile(path, TEncoding.UTF8);
+      // Successfully read as UTF-8; nothing to do.
+      Exit;
+    except
+      // Not valid UTF-8: fall back to legacy encoding (CP1252) and convert to UTF-8
+    end;
+
+    enc1252 := nil;
+    try
+      enc1252 := TEncoding.GetEncoding(1252);
+      sl.LoadFromFile(path, enc1252);
+      sl.SaveToFile(path, TEncoding.UTF8);
+    finally
+      enc1252.Free;
+    end;
+  finally
+    sl.Free;
+  end;
+end;
+
+function TfmIndex.abreIniLiturgia: TMemIniFile;
+var
+  path: string;
+  sl: TStringList;
+  enc1252: TEncoding;
+  backupPath: string;
+begin
+  path := caminhoLiturgia;
+  try
+    // Ensure file is converted to UTF-8 where possible
+    try
+      garanteUtf8Liturgia;
+    except
+      try gravaLog('abreIniLiturgia: garanteUtf8Liturgia falhou para ' + path); except end;
+    end;
+
+    try
+      gravaLog('abreIniLiturgia: opening ' + path + ' (ensured UTF-8)');
+    except
+      // best effort
+    end;
+
+    try
+      Result := TMemIniFile.Create(path, TEncoding.UTF8);
+      Exit;
+    except
+      on E: EEncodingError do
+      begin
+        try
+          gravaLog('abreIniLiturgia: EEncodingError creating TMemIniFile for ' + path + ' - ' + E.Message);
+        except end;
+
+        // Try a forced conversion: read as CP1252 and rewrite as UTF-8
+        try
+          sl := TStringList.Create;
+          try
+            enc1252 := TEncoding.GetEncoding(1252);
+            try
+              sl.LoadFromFile(path, enc1252);
+              sl.SaveToFile(path, TEncoding.UTF8);
+            finally
+              enc1252.Free;
+            end;
+          finally
+            sl.Free;
+          end;
+        except
+          try gravaLog('abreIniLiturgia: repair (CP1252->UTF8) failed for ' + path); except end;
+          // Backup corrupted file and create an empty one
+          try
+            backupPath := path + '.corrupt.' + FormatDateTime('yyyymmddhhnnsszzz', Now);
+            RenameFile(path, backupPath);
+            gravaLog('abreIniLiturgia: moved corrupted file to ' + backupPath);
+          except
+            try gravaLog('abreIniLiturgia: failed to backup corrupted file ' + path); except end;
+          end;
+          // create an empty file to continue
+          try
+            sl := TStringList.Create;
+            try
+              sl.SaveToFile(path, TEncoding.UTF8);
+            finally
+              sl.Free;
+            end;
+          except
+            // give up and re-raise original error
+            raise;
+          end;
+        end;
+
+        // Try creating again after repair/backout
+        try
+          Result := TMemIniFile.Create(path, TEncoding.UTF8);
+          Exit;
+        except
+          on E2: Exception do
+          begin
+            try gravaLog('abreIniLiturgia: second attempt failed for ' + path + ' - ' + E2.ClassName + ' - ' + E2.Message); except end;
+            // as last resort, backup and create empty ini
+            try
+              backupPath := path + '.corrupt.' + FormatDateTime('yyyymmddhhnnsszzz', Now);
+              if FileExists(path) then RenameFile(path, backupPath);
+            except
+              // ignore
+            end;
+            Result := TMemIniFile.Create(path, TEncoding.UTF8);
+            Exit;
+          end;
+        end;
+      end
+      else
+        raise;
+    end;
+  except
+    on E: Exception do
+    begin
+      try
+        gravaLog('abreIniLiturgia: erro ao abrir ' + path + ' - ' + E.ClassName + ' - ' + E.Message);
+      except end;
+      raise;
+    end;
+  end;
+end;
+
+procedure TfmIndex.gravaLog(txt:string);
+const
+  LIMITE_BYTES = 1048576;     // 1MB
+  ALVO_BYTES   = 730 * 1024;  // ~70% do limite
+var
+  linha, path: string;
+  tamanho, soma: Int64;
+  fs: TFileStream;
+  sl: TStringList;
+  i, corte: Integer;
+begin
+  linha := FormatDateTime('dd/mm/yyyy HH:MM:SS.ZZZ', now()) + '    ' + txt;
+
+  try
+    if mmLog <> nil then
+      mmLog.Lines.Add(linha);
+  except
+    // Silencioso se mmLog falhar
+  end;
+
+  // Persistência em disco só em modo desenvolvedor
+  if (pnlModDes = nil) or (not pnlModDes.Visible) then Exit;
+  if dir_dados = '' then Exit;
+
+  Inc(FLogChamadas);
+
+  path := dir_dados + 'louvorja.log';
+  try
+    TFile.AppendAllText(path, linha + sLineBreak, TEncoding.UTF8);
+
+    // Só checa truncamento a cada 100 chamadas para não pagar custo em todo log
+    if (FLogChamadas mod 100) <> 0 then Exit;
+
+    if not FileExists(path) then Exit;
+    fs := TFileStream.Create(path, fmOpenRead or fmShareDenyNone);
+    try
+      tamanho := fs.Size;
+    finally
+      fs.Free;
+    end;
+    if tamanho <= LIMITE_BYTES then Exit;
+
+    sl := TStringList.Create;
+    try
+      sl.LoadFromFile(path, TEncoding.UTF8);
+      soma := 0;
+      corte := 0;
+      for i := sl.Count - 1 downto 0 do
+      begin
+        Inc(soma, Length(sl[i]) + 2); // +2 = CRLF
+        if soma > ALVO_BYTES then
+        begin
+          corte := i + 1; // qtde de linhas iniciais a remover
+          Break;
+        end;
+      end;
+      for i := 1 to corte do
+        sl.Delete(0);
+      sl.SaveToFile(path, TEncoding.UTF8);
+    finally
+      sl.Free;
+    end;
+  except
+    // Silencioso por design: falha do log não pode quebrar o app nem causar recursão
+  end;
+end;
+
+procedure TfmIndex.gravaParamLote(const Arquivo: string; const Itens: array of TParamItem);
+var
+  ArqIni: TCustomIniFile;
+  i: Integer;
+  arq: string;
+  origPath, tempPath: string;
+  origIni, tempIni: TMemIniFile;
+  sections, keys: TStringList;
+
+  var k : integer;
+  var backup : string;
+begin
+  arq := Arquivo;
+  if arq = '' then
+    arq := 'config' + fIniciando.LANG + '.ja';
+
+  try
+    if arq = arq_liturgia then
+    begin
+      // Write atomically: copy existing INI to temp, apply changes, write temp and replace
+      origPath := dir_dados + arq;
+      tempPath := origPath + '.tmp';
+
+      // Ensure liturgia.ja is in UTF-8 before attempting to read it
+      try
+        garanteUtf8Liturgia;
+      except
+        try gravaLog('gravaParamLote: garanteUtf8Liturgia failed for ' + origPath); except end;
+      end;
+
+      tempIni := TMemIniFile.Create(tempPath, TEncoding.UTF8);
+      try
+        if FileExists(origPath) then
+        begin
+          try
+            origIni := TMemIniFile.Create(origPath, TEncoding.UTF8);
+            try
+              sections := TStringList.Create;
+              try
+                origIni.ReadSections(sections);
+                for i := 0 to sections.Count - 1 do
+                begin
+                  keys := TStringList.Create;
+                  try
+                    origIni.ReadSection(sections[i], keys);
+                    for k := 0 to keys.Count - 1 do
+                      tempIni.WriteString(sections[i], keys[k], origIni.ReadString(sections[i], keys[k], ''));
+                  finally
+                    keys.Free;
+                  end;
+                end;
+              finally
+                sections.Free;
+              end;
+            finally
+              origIni.Free;
+            end;
+          except
+            on E: Exception do
+            begin
+              // Orig file could be corrupt or unreadable; backup and continue with empty base
+              try
+                gravaLog('gravaParamLote: failed to read orig INI ' + origPath + ' - ' + E.ClassName + ' - ' + E.Message);
+              except end;
+              try
+                backup := origPath + '.corrupt.' + FormatDateTime('yyyymmddhhnnsszzz', Now);
+                if FileExists(origPath) then RenameFile(origPath, backup);
+                gravaLog('gravaParamLote: moved corrupted orig INI to ' + backup);
+              except
+                try gravaLog('gravaParamLote: failed to backup corrupted orig INI ' + origPath); except end;
+              end;
+              // proceed without copying original contents
+            end;
+          end;
+        end;
+
+        for i := 0 to High(Itens) do
+          tempIni.WriteString(Itens[i].Grupo, Itens[i].Param, Itens[i].Valor);
+
+        tempIni.UpdateFile;
+      finally
+        tempIni.Free;
+      end;
+
+      // Replace original atomically (replace if exists)
+      if not MoveFileEx(PChar(tempPath), PChar(origPath), MOVEFILE_REPLACE_EXISTING) then
+      begin
+        // Attempt fallback: delete original then rename
+        try
+          if FileExists(origPath) then
+            DeleteFile(origPath);
+          RenameFile(tempPath, origPath);
+        except
+          raise;
+        end;
+      end;
+    end
+    else
+    begin
+      ArqIni := TIniFile.Create(dir_dados + arq);
+      try
+        for i := 0 to High(Itens) do
+          ArqIni.WriteString(Itens[i].Grupo, Itens[i].Param, Itens[i].Valor);
+        ArqIni.UpdateFile;
+      finally
+        ArqIni.Free;
+      end;
+    end;
+  except
+    on E: Exception do
+      gravaLog('gravaParamLote(' + arq + '): ' + E.ClassName + ' - ' + E.Message);
+  end;
 end;
 
 procedure TfmIndex.gravaParam(Grupo, Param, Valor, Arquivo: string);
 var
-  ArqIni: TCustomIniFile;
+  item: TParamItem;
 begin
-  if Arquivo = '' then
-    Arquivo := 'config'+fIniciando.LANG+'.ja';
-
-  try
-    if Arquivo = arq_liturgia then
-      ArqIni := TMemIniFile.Create(dir_dados + Arquivo, TEncoding.UTF8)
-    else
-      ArqIni := TIniFile.Create(dir_dados + Arquivo);
-    try
-      ArqIni.WriteString(Grupo, Param, Valor);
-      ArqIni.UpdateFile;
-    finally
-      ArqIni.Free;
-    end;
-  except
-    //
-  end;
+  item.Grupo := Grupo;
+  item.Param := Param;
+  item.Valor := Valor;
+  gravaParamLote(Arquivo, [item]);
 end;
 
 procedure TfmIndex.gravaParamServer(Grupo, Param, Valor: string);
@@ -6353,18 +6677,23 @@ begin
   if Arquivo = '' then
     Arquivo := 'config'+fIniciando.LANG+'.ja';
 
-  if Arquivo = arq_liturgia then
-    ArqIni := TMemIniFile.Create(dir_dados + Arquivo, TEncoding.UTF8)
-  else
-    ArqIni := TIniFile.Create(dir_dados + Arquivo);
   try
-    if (trim(Param) <> '') then
-      ArqIni.DeleteKey(Grupo, Param)
+    if Arquivo = arq_liturgia then
+      ArqIni := abreIniLiturgia
     else
-      ArqIni.EraseSection(Grupo);
-    ArqIni.UpdateFile;
-  finally
-    ArqIni.Free;
+      ArqIni := TIniFile.Create(dir_dados + Arquivo);
+    try
+      if (trim(Param) <> '') then
+        ArqIni.DeleteKey(Grupo, Param)
+      else
+        ArqIni.EraseSection(Grupo);
+      ArqIni.UpdateFile;
+    finally
+      ArqIni.Free;
+    end;
+  except
+    on E: Exception do
+      gravaLog('apagaParam(' + Arquivo + ',' + Grupo + ',' + Param + '): ' + E.ClassName + ' - ' + E.Message);
   end;
 end;
 


### PR DESCRIPTION
Corrige Codificação: bytes Win-1252 misturados em `liturgia.ja` causavam `?` nos campos e corrompiam dados ao salvar.

## Mudanças principais

- `garanteUtf8Liturgia`: detecta sem BOM; converte CP1252→UTF-8; fallback para `.corrupt.<ts>`
- `gravaParamLote`: escrita atômica via `.tmp` + `MoveFileEx`
- `lerParam/gravaParam/apagaParam`: logam exceções em vez de `except //` silencioso
- `btAddClick`: 12 gravações sequenciais → 1 lote atômico