### PR TITLE
Correção de verificação da rota /api/song-slides?action=next

### DIFF
--- a/fmTransmitir.pas
+++ b/fmTransmitir.pas
@@ -386,7 +386,7 @@ begin
     begin
       if (ARequestInfo.Params.Values['action'] = 'next') then
       begin
-        if (fMusica.Visible) then
+        if (fMusica <> nil) and (fMusica.Visible) then
         begin
           fMusica.acaoSlide('prox');
           AResponseInfo.ContentText := '{"status":"ok","message":"Advanced to the next slide","code":"ADVANCED_SLIDE"}';


### PR DESCRIPTION
Havia uma falha na verificação do next onde se o form de música não tivesse sido aberto na instância atual do Louvor JA, ele retornava um erro do próprio programa. Após abrir uma música não ocorria mais, mesmo após fechá-la. Foi adicionada a verificação correta para evitar esse bug.