### PR TITLE
feat(liturgia): drag-and-drop na liturgia e melhoria de visualização do caminho

### DIFF
--- a/fmLiturgia.pas
+++ b/fmLiturgia.pas
@@ -82,6 +82,7 @@ type
   public
     { Public declarations }
     id: string;
+    arquivoInicial: string;
   end;
 
 var
@@ -101,6 +102,8 @@ end;
 procedure TfLiturgia.edtDiretorioExit(Sender: TObject);
 begin
   edtDiretorio.Text := fmIndex.verificaURL(edtDiretorio.Text, edtDiretorioInfo, false);
+  edtDiretorio.SelStart := Length(edtDiretorio.Text);
+  edtDiretorio.Perform(EM_SCROLLCARET, 0, 0);
 end;
 
 procedure TfLiturgia.bsSkinSpeedButton1Click(Sender: TObject);
@@ -450,6 +453,8 @@ begin
     begin
       edtDiretorio.Text := fmIndex.lerParam(id, 'dir', '', fmIndex.arq_liturgia);
       edtDiretorioInfo.Text := fmIndex.lerParam(id, 'dir_info', '', fmIndex.arq_liturgia);
+      edtDiretorio.SelStart := Length(edtDiretorio.Text);
+      edtDiretorio.Perform(EM_SCROLLCARET, 0, 0);
     end
     else
     begin
@@ -490,6 +495,17 @@ begin
   except
     cbItens.ItemIndex := -1;
     try fmIndex.gravaLog('FormActivate: excecao ao carregar item ' + id); except end;
+  end;
+
+  // Pré-preenchimento via drag-and-drop de arquivo na liturgia
+  if (Trim(arquivoInicial) <> '') and (Trim(id) = '') then
+  begin
+    cbItens.ItemIndex := 1; // Arquivo
+    cbItensChange(nil);
+    edtDiretorio.Text := arquivoInicial;
+    edtDiretorioExit(nil);
+    arquivoInicial := '';
+    if txtItem.CanFocus then txtItem.SetFocus;
   end;
 end;
 

--- a/fmMenu.pas
+++ b/fmMenu.pas
@@ -2266,6 +2266,9 @@ type
     //Define tamanho da tel maximizada (evita que form fique embaixo da barra de tarefas)
     procedure WMGetMinmaxInfo(var Msg: TWMGetMinmaxInfo); message WM_GETMINMAXINFO;
 
+    //Aceita arquivos arrastados do Windows Explorer (drop na aba Liturgia)
+    procedure WMDropFiles(var Msg: TWMDropFiles); message WM_DROPFILES;
+
     //Define as ações para quando perder ou receber o foco
     procedure ApplicationDeactivate(Sender: TObject);
     procedure ApplicationActivate(Sender: TObject);
@@ -2375,10 +2378,13 @@ begin
   SetWindowLong(fmIndex.Handle,
                 GWL_STYLE,
                 GetWindowLong(Handle,GWL_STYLE) and not WS_CAPTION);
+
+  DragAcceptFiles(Self.Handle, True);
 end;
 
 procedure TfmIndex.FormDestroy(Sender: TObject);
 begin
+  DragAcceptFiles(Self.Handle, False);
   RichEdit1Exit(Sender);
   usaFontes(false);
   RecursiveDelete(dir_temp);
@@ -11985,6 +11991,37 @@ begin
   fLiturgia.Caption := 'Adicionar Item';
   fLiturgia.id := '';
   fLiturgia.ShowModal;
+end;
+
+procedure TfmIndex.WMDropFiles(var Msg: TWMDropFiles);
+var
+  numFiles, i, size: Integer;
+  buffer: array[0..MAX_PATH] of Char;
+begin
+  try
+    if not ((PageControl1.Visible) and (PageControl1.ActivePage = tsLiturgia)) then
+    begin
+      Msg.Result := 0;
+      Exit;
+    end;
+
+    numFiles := DragQueryFile(Msg.Drop, $FFFFFFFF, nil, 0);
+    for i := 0 to numFiles - 1 do
+    begin
+      size := DragQueryFile(Msg.Drop, i, nil, 0) + 1;
+      if size > SizeOf(buffer) then size := SizeOf(buffer);
+      DragQueryFile(Msg.Drop, i, buffer, size);
+
+      fIniciando.AppCreateForm(TfLiturgia, fLiturgia);
+      fLiturgia.Caption := 'Adicionar Item';
+      fLiturgia.id := '';
+      fLiturgia.arquivoInicial := buffer;
+      fLiturgia.ShowModal;
+    end;
+  finally
+    DragFinish(Msg.Drop);
+    Msg.Result := 0;
+  end;
 end;
 
 procedure TfmIndex.bsSkinSpeedButton8Click(Sender: TObject);


### PR DESCRIPTION
Permite arrastar arquivos do Windows Explorer para a aba Liturgia, abrindo o modal de adição de item com o tipo "Arquivo" pré-selecionado, caminho preenchido e foco no campo Nome. Múltiplos arquivos abrem o modal em sequência.

O campo de caminho do arquivo agora rola para o final ao perder o foco e ao carregar item salvo, garantindo que o nome do arquivo fique sempre visível quando o caminho excede a largura do campo.